### PR TITLE
fix: prefix index with table name to avoid collisions on some databases

### DIFF
--- a/database/migrations/2025_04_13_061226_create_dcb_events_table.php
+++ b/database/migrations/2025_04_13_061226_create_dcb_events_table.php
@@ -31,7 +31,7 @@ return new class extends Migration {
             });
 
             if (Schema::getConnection()->getDriverName() === 'pgsql') {
-                DB::statement("create index tags on {$tableName} using gin(tags jsonb_path_ops)");
+                DB::statement("create index {$tableName}_tags on {$tableName} using gin(tags jsonb_path_ops)");
             }
         }
     }


### PR DESCRIPTION
Some databases must have index names unique at database level instead of table level