### PR TITLE
Add retry and backoff strategies for commits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,7 @@
         "test:cs": "phpcs --colors src",
         "test:cs:fix": "phpcbf --colors src",
         "test:integration": [
-            "echo $DCB_TEST_DSN",
-            "phpunit tests/Integration/IlluminateEventStoreTest.php --exclude-group=parallel --exclude-group=feature_liveStream --exclude-group=feature_appendConditionWithoutMatchingEvent"
+            "phpunit tests --exclude-group=parallel --exclude-group=validate --exclude-group=feature_liveStream --exclude-group=feature_appendConditionWithoutMatchingEvent"
         ],
         "test:consistency": [
             "EKvedaras\\DCBEventStoreIlluminate\\Tests\\Integration\\ConcurrencyTest::prepare",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "webmozart/assert": "^1.11",
         "wwwision/dcb-eventstore": "^4",
         "illuminate/database": "^11|^12",
-        "illuminate/support": "^11|^12"
+        "illuminate/support": "^11|^12",
+        "nesbot/carbon": "^3"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",

--- a/src/CommitRetries/BackoffExponentially.php
+++ b/src/CommitRetries/BackoffExponentially.php
@@ -13,7 +13,7 @@ final readonly class BackoffExponentially implements BackoffStrategy
         public int $maxAttempts = 10,
         public CarbonInterval $waitInitiallyFor = new CarbonInterval(seconds: 0.1),
         /** @var positive-int|float */
-        public int|float $rate = 2,
+        public int|float $rate = 3,
     ) {
     }
 

--- a/src/CommitRetries/BackoffExponentially.php
+++ b/src/CommitRetries/BackoffExponentially.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EKvedaras\DCBEventStoreIlluminate\CommitRetries;
+
+use Carbon\CarbonInterval;
+
+final readonly class BackoffExponentially implements BackoffStrategy
+{
+    public function __construct(
+        /** @var positive-int */
+        public int $maxAttempts = 10,
+        public CarbonInterval $waitInitiallyFor = new CarbonInterval(seconds: 0.1),
+        /** @var positive-int|float */
+        public int|float $rate = 2,
+    ) {
+    }
+
+    public function canRetry(int $exhaustedAttempts): bool
+    {
+        return $exhaustedAttempts < $this->maxAttempts;
+    }
+
+    public function getNextRetryWaitTime(?CarbonInterval $current, int $exhaustedAttempts): CarbonInterval
+    {
+        return $this->waitInitiallyFor->multiply($this->rate ** $exhaustedAttempts);
+    }
+}

--- a/src/CommitRetries/BackoffLinearly.php
+++ b/src/CommitRetries/BackoffLinearly.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EKvedaras\DCBEventStoreIlluminate\CommitRetries;
+
+use Carbon\CarbonInterval;
+
+final readonly class BackoffLinearly implements BackoffStrategy
+{
+    public function __construct(
+        /** @var positive-int */
+        public int $maxAttempts = 10,
+        public CarbonInterval $waitInitiallyFor = new CarbonInterval(seconds: 0.1),
+        /** @var positive-int|float */
+        public int|float $waitTimeMultiplier = 3,
+    ) {
+    }
+
+    public function canRetry(int $exhaustedAttempts): bool
+    {
+        return $exhaustedAttempts < $this->maxAttempts;
+    }
+
+    public function getNextRetryWaitTime(?CarbonInterval $current, int $exhaustedAttempts): CarbonInterval
+    {
+        return $current?->multiply($this->waitTimeMultiplier) ?? $this->waitInitiallyFor;
+    }
+}

--- a/src/CommitRetries/BackoffStrategy.php
+++ b/src/CommitRetries/BackoffStrategy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EKvedaras\DCBEventStoreIlluminate\CommitRetries;
+
+use Carbon\CarbonInterval;
+
+interface BackoffStrategy
+{
+    public function canRetry(int $exhaustedAttempts): bool;
+
+    /** @param non-negative-int $exhaustedAttempts */
+    public function getNextRetryWaitTime(?CarbonInterval $current, int $exhaustedAttempts): CarbonInterval;
+}

--- a/src/CommitRetries/CommitRetryStrategy.php
+++ b/src/CommitRetries/CommitRetryStrategy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EKvedaras\DCBEventStoreIlluminate\CommitRetries;
+
+use Throwable;
+
+interface CommitRetryStrategy
+{
+    public function shouldRetry(Throwable $exception): bool;
+}

--- a/src/CommitRetries/RetryCommitOnDeadLock.php
+++ b/src/CommitRetries/RetryCommitOnDeadLock.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EKvedaras\DCBEventStoreIlluminate\CommitRetries;
+
+use Illuminate\Contracts\Database\ConcurrencyErrorDetector;
+use Illuminate\Database\ConcurrencyErrorDetector as PdoCodeOrMessageBasedDeadLockDetector;
+use Throwable;
+
+final readonly class RetryCommitOnDeadLock implements CommitRetryStrategy
+{
+    public function __construct(
+        private ConcurrencyErrorDetector $detector = new PdoCodeOrMessageBasedDeadLockDetector(),
+    ) {
+    }
+
+    public function shouldRetry(Throwable $exception): bool
+    {
+        return $this->detector->causedByConcurrencyError($exception);
+    }
+}

--- a/src/IlluminateEventStoreConfiguration.php
+++ b/src/IlluminateEventStoreConfiguration.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace EKvedaras\DCBEventStoreIlluminate;
 
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffLinearly;
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffStrategy;
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\CommitRetryStrategy;
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\RetryCommitOnDeadLock;
 use Illuminate\Database\Connection;
 use Psr\Clock\ClockInterface;
 use Wwwision\DCBEventStore\Helpers\SystemClock;
@@ -14,20 +18,50 @@ final readonly class IlluminateEventStoreConfiguration
         public Connection $connection,
         public string $eventTableName,
         public ClockInterface $clock,
+        public CommitRetryStrategy $commitRetryStrategy = new RetryCommitOnDeadLock(),
+        public BackoffStrategy $backoffStrategy = new BackoffLinearly(),
     ) {
     }
 
     public static function create(Connection $connection, string $eventTableName): self
     {
         return new self(
-            $connection,
-            $eventTableName,
-            new SystemClock(),
+            connection:     $connection,
+            eventTableName: $eventTableName,
+            clock:          new SystemClock(),
         );
     }
 
     public function withClock(ClockInterface $clock): self
     {
-        return new self($this->connection, $this->eventTableName, $clock);
+        return new self(
+            connection: $this->connection,
+            eventTableName: $this->eventTableName,
+            clock: $clock,
+            commitRetryStrategy: $this->commitRetryStrategy,
+            backoffStrategy: $this->backoffStrategy,
+        );
+    }
+
+    public function withCommitRetryStrategy(CommitRetryStrategy $strategy): self
+    {
+        return new self(
+            connection:          $this->connection,
+            eventTableName:      $this->eventTableName,
+            clock:               $this->clock,
+            commitRetryStrategy: $strategy,
+            backoffStrategy:     $this->backoffStrategy,
+        );
+    }
+
+    public function withBackoffStrategy(BackoffStrategy $strategy): self
+    {
+        return new self(
+            connection:          $this->connection,
+            eventTableName:      $this->eventTableName,
+            clock:               $this->clock,
+            commitRetryStrategy: $this->commitRetryStrategy,
+            backoffStrategy:     $strategy,
+        );
     }
 }

--- a/src/IlluminateEventStoreConfiguration.php
+++ b/src/IlluminateEventStoreConfiguration.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace EKvedaras\DCBEventStoreIlluminate;
 
 use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffExponentially;
-use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffLinearly;
 use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffStrategy;
 use EKvedaras\DCBEventStoreIlluminate\CommitRetries\CommitRetryStrategy;
 use EKvedaras\DCBEventStoreIlluminate\CommitRetries\RetryCommitOnDeadLock;

--- a/src/IlluminateEventStoreConfiguration.php
+++ b/src/IlluminateEventStoreConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace EKvedaras\DCBEventStoreIlluminate;
 
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffExponentially;
 use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffLinearly;
 use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffStrategy;
 use EKvedaras\DCBEventStoreIlluminate\CommitRetries\CommitRetryStrategy;
@@ -19,7 +20,7 @@ final readonly class IlluminateEventStoreConfiguration
         public string $eventTableName,
         public ClockInterface $clock,
         public CommitRetryStrategy $commitRetryStrategy = new RetryCommitOnDeadLock(),
-        public BackoffStrategy $backoffStrategy = new BackoffLinearly(),
+        public BackoffStrategy $backoffStrategy = new BackoffExponentially(),
     ) {
     }
 

--- a/tests/CommitRetries/BackoffExponentiallyTest.php
+++ b/tests/CommitRetries/BackoffExponentiallyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EKvedaras\DCBEventStoreIlluminate\Tests\CommitRetries;
+
+use Carbon\CarbonInterval;
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffExponentially;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BackoffExponentially::class)]
+final class BackoffExponentiallyTest extends TestCase
+{
+    public function test_can_retry_until_max_attempts(): void
+    {
+        $strategy = new BackoffExponentially(maxAttempts: 3);
+
+        self::assertTrue($strategy->canRetry(0));
+        self::assertTrue($strategy->canRetry(2));
+        self::assertFalse($strategy->canRetry(3));
+    }
+
+    public function test_wait_time_grows_exponentially(): void
+    {
+        $waitInitiallyFor = CarbonInterval::milliseconds(100);
+        $strategyFactory = static fn (): BackoffExponentially => new BackoffExponentially(
+            maxAttempts: 5,
+            waitInitiallyFor: clone $waitInitiallyFor,
+            rate: 3,
+        );
+
+        $firstWait = $strategyFactory()->getNextRetryWaitTime(current: null, exhaustedAttempts: 0);
+        $secondWait = $strategyFactory()->getNextRetryWaitTime(current: null, exhaustedAttempts: 1);
+        $thirdWait = $strategyFactory()->getNextRetryWaitTime(current: null, exhaustedAttempts: 2);
+
+        self::assertSame(100, (int) $firstWait->totalMilliseconds);
+        self::assertSame(300, (int) $secondWait->totalMilliseconds);
+        self::assertSame(900, (int) $thirdWait->totalMilliseconds);
+    }
+}

--- a/tests/CommitRetries/BackoffLinearlyTest.php
+++ b/tests/CommitRetries/BackoffLinearlyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EKvedaras\DCBEventStoreIlluminate\Tests\CommitRetries;
+
+use Carbon\CarbonInterval;
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffLinearly;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BackoffLinearly::class)]
+final class BackoffLinearlyTest extends TestCase
+{
+    public function test_can_retry_until_max_attempts(): void
+    {
+        $strategy = new BackoffLinearly(maxAttempts: 2);
+
+        self::assertTrue($strategy->canRetry(0));
+        self::assertTrue($strategy->canRetry(1));
+        self::assertFalse($strategy->canRetry(2));
+    }
+
+    public function test_wait_time_grows_linearly(): void
+    {
+        $initialInterval = CarbonInterval::milliseconds(200);
+        $strategy = new BackoffLinearly(
+            maxAttempts: 4,
+            waitInitiallyFor: $initialInterval,
+            waitTimeMultiplier: 2,
+        );
+
+        $firstWait = $strategy->getNextRetryWaitTime(current: null, exhaustedAttempts: 0);
+        $secondWait = $strategy->getNextRetryWaitTime(current: clone $firstWait, exhaustedAttempts: 1);
+        $thirdWait = $strategy->getNextRetryWaitTime(current: clone $secondWait, exhaustedAttempts: 2);
+
+        self::assertSame(200, (int) $firstWait->totalMilliseconds);
+        self::assertSame(400, (int) $secondWait->totalMilliseconds);
+        self::assertSame(800, (int) $thirdWait->totalMilliseconds);
+    }
+}

--- a/tests/IlluminateEventStoreConfigurationTest.php
+++ b/tests/IlluminateEventStoreConfigurationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EKvedaras\DCBEventStoreIlluminate\Tests;
+
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffExponentially;
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\BackoffStrategy;
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\CommitRetryStrategy;
+use EKvedaras\DCBEventStoreIlluminate\CommitRetries\RetryCommitOnDeadLock;
+use EKvedaras\DCBEventStoreIlluminate\IlluminateEventStoreConfiguration;
+use Illuminate\Database\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Wwwision\DCBEventStore\Helpers\SystemClock;
+
+#[CoversClass(IlluminateEventStoreConfiguration::class)]
+final class IlluminateEventStoreConfigurationTest extends TestCase
+{
+    public function test_create_uses_default_dependencies(): void
+    {
+        $connection = $this->createStub(Connection::class);
+
+        $config = IlluminateEventStoreConfiguration::create($connection, 'events');
+
+        self::assertSame($connection, $config->connection);
+        self::assertSame('events', $config->eventTableName);
+        self::assertInstanceOf(SystemClock::class, $config->clock);
+        self::assertInstanceOf(RetryCommitOnDeadLock::class, $config->commitRetryStrategy);
+        self::assertInstanceOf(BackoffExponentially::class, $config->backoffStrategy);
+    }
+
+    public function test_with_clock_returns_new_instance_with_replaced_clock(): void
+    {
+        $connection = $this->createStub(Connection::class);
+        $initialClock = $this->createStub(ClockInterface::class);
+        $commitRetryStrategy = $this->createStub(CommitRetryStrategy::class);
+        $backoffStrategy = $this->createStub(BackoffStrategy::class);
+
+        $config = new IlluminateEventStoreConfiguration(
+            connection: $connection,
+            eventTableName: 'events',
+            clock: $initialClock,
+            commitRetryStrategy: $commitRetryStrategy,
+            backoffStrategy: $backoffStrategy,
+        );
+
+        $newClock = $this->createStub(ClockInterface::class);
+
+        $newConfig = $config->withClock($newClock);
+
+        self::assertNotSame($config, $newConfig);
+        self::assertSame($newClock, $newConfig->clock);
+        self::assertSame($initialClock, $config->clock);
+        self::assertSame($connection, $newConfig->connection);
+        self::assertSame($commitRetryStrategy, $newConfig->commitRetryStrategy);
+        self::assertSame($backoffStrategy, $newConfig->backoffStrategy);
+    }
+
+    public function test_with_commit_retry_strategy_returns_new_instance_with_replaced_strategy(): void
+    {
+        $connection = $this->createStub(Connection::class);
+        $clock = $this->createStub(ClockInterface::class);
+        $initialCommitRetry = $this->createStub(CommitRetryStrategy::class);
+        $backoffStrategy = $this->createStub(BackoffStrategy::class);
+
+        $config = new IlluminateEventStoreConfiguration(
+            connection: $connection,
+            eventTableName: 'events',
+            clock: $clock,
+            commitRetryStrategy: $initialCommitRetry,
+            backoffStrategy: $backoffStrategy,
+        );
+
+        $newCommitRetry = $this->createStub(CommitRetryStrategy::class);
+
+        $newConfig = $config->withCommitRetryStrategy($newCommitRetry);
+
+        self::assertNotSame($config, $newConfig);
+        self::assertSame($newCommitRetry, $newConfig->commitRetryStrategy);
+        self::assertSame($initialCommitRetry, $config->commitRetryStrategy);
+        self::assertSame($clock, $newConfig->clock);
+        self::assertSame($connection, $newConfig->connection);
+        self::assertSame($backoffStrategy, $newConfig->backoffStrategy);
+    }
+
+    public function test_with_backoff_strategy_returns_new_instance_with_replaced_strategy(): void
+    {
+        $connection = $this->createStub(Connection::class);
+        $clock = $this->createStub(ClockInterface::class);
+        $commitRetryStrategy = $this->createStub(CommitRetryStrategy::class);
+        $initialBackoff = $this->createStub(BackoffStrategy::class);
+
+        $config = new IlluminateEventStoreConfiguration(
+            connection: $connection,
+            eventTableName: 'events',
+            clock: $clock,
+            commitRetryStrategy: $commitRetryStrategy,
+            backoffStrategy: $initialBackoff,
+        );
+
+        $newBackoff = $this->createStub(BackoffStrategy::class);
+
+        $newConfig = $config->withBackoffStrategy($newBackoff);
+
+        self::assertNotSame($config, $newConfig);
+        self::assertSame($newBackoff, $newConfig->backoffStrategy);
+        self::assertSame($initialBackoff, $config->backoffStrategy);
+        self::assertSame($clock, $newConfig->clock);
+        self::assertSame($connection, $newConfig->connection);
+        self::assertSame($commitRetryStrategy, $newConfig->commitRetryStrategy);
+    }
+}

--- a/tests/Integration/IlluminateEventStoreTest.php
+++ b/tests/Integration/IlluminateEventStoreTest.php
@@ -7,6 +7,7 @@ namespace EKvedaras\DCBEventStoreIlluminate\Tests\Integration;
 use EKvedaras\DCBEventStoreIlluminate\Tests\OrchestraTestBench;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Sleep;
 use PHPUnit\Framework\Attributes\CoversClass;
 use EKvedaras\DCBEventStoreIlluminate\IlluminateEventStore;
 
@@ -25,6 +26,8 @@ final class IlluminateEventStoreTest extends EventStoreTestBase
         Assert::isInstanceOf($connection, Connection::class);
         $eventStore = IlluminateEventStore::create($connection, config('dcb_event_store.events_table_name'));
         $connection->table(config('dcb_event_store.events_table_name'))->truncate();
+
+        Sleep::fake();
 
         return $eventStore;
     }


### PR DESCRIPTION
### Description

This pull request introduces retry and backoff strategies to improve the reliability of commit operations. These changes add mechanisms to handle transient errors by retrying with an exponential backoff delay.

### Checklist

- [ ] Update documentation if applicable
- [x] Add tests to cover changes if needed
- [ ] Ensure all existing and new tests pass